### PR TITLE
examples: Add new example blueprints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ before_script:
 
 script:
     - gulp lint test
+    - mkdir -p ~/.kelda/infra/ && mv ./testInfra.js ~/.kelda/infra/default.js
     - ./kelda inspect ./haproxy.js graphviz
+    - ./kelda inspect ./examples/haproxyExampleSingleApp.js graphviz
+    - ./kelda inspect ./examples/haproxyExampleMultipleApps.js graphviz
 
 notifications:
     slack:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ arguments:
 HAProxy will communicate with the containers behind it on port 80.
 
 #### Example
+*See [a full example](./examples/haproxyExampleSingleApp.js) in the `examples`
+directory*.
+
 ```javascript
 const {Container} = require('kelda');
 const haproxy = require('@kelda/haproxy');
@@ -48,6 +51,8 @@ to the containers that should receive traffic for that domain.
 HAProxy will communicate with the services behind it on port 80.
 
 #### Example
+*See [a full example](./examples/haproxyExampleMultipleApps.js) in the
+`examples` directory*.
 
 ```javascript
 const webAContainers = [];

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,64 @@
+# HAProxy Examples with Kelda
+
+This directory contains examples for Kelda's HAProxy blueprint.
+
+To run the example blueprints:
+1. [**Install Kelda**](http://docs.kelda.io/#installing-kelda) with
+    ```console
+    $ npm install -g @kelda/install
+    ```
+2. **Get the blueprints** by cloning this repository.
+    ```console
+    $ git clone https://github.com/kelda/haproxy
+    ```
+3. **Set up an infrastructure** by running `kelda init`. In the first question, name your infrastructure `default`.
+4. **Install dependencies** by running `npm install` in the cloned
+  `haproxy` directory.
+5. **Start Kelda** by running `kelda daemon` in a different terminal window.
+6. **Boot the applications** by running one of the following commands from
+  this `haproxy/examples` directory.
+
+    ```console
+    $ kelda run ./haproxyExampleSingleApp.js
+    ```
+    or
+    ```console
+    $ kelda run ./haproxyExampleMultipleApps.js
+    ```
+7. **Stop the deployment** with `kelda stop` when you're done, and then kill
+  the daemon with ctrl+c.
+
+## Accessing the applications
+#### `haproxyExampleSingleApp.js`
+Use `kelda show` to check the status of the deployment. When all the containers
+are running, simply copy paste the `PUBLIC IP` of the `haproxy` container into
+a browser. If everything booted correctly, it should say "Hello, world!".
+
+#### `haproxyExampleMultipleApps.js`
+This blueprint boots two applications with the domain names `apples.com` and
+`oranges.com` respectively. Both applications sit behind the HAProxy load
+balancer, so they will have the same IP address. For that reason, we can't
+simply access the applications through the IP as we did above.
+
+Instead, we have to also include the domain name of the application we want to
+access. This way the load balancer knows which servers to redirect our request
+to. When all the containers are `running`, check that you can access both
+applications by running the following commands from your terminal, and checking
+the responses:
+
+```console
+$ curl -H "Host: apples.com" HAPROXY_PUBLIC_IP
+Apples!
+$ curl -H "Host: oranges.com" HAPROXY_PUBLIC_IP
+Oranges!
+```
+
+To make your applications accessible through a browser, buy your domain names
+through a registrar like Namecheap, and map the domains to the IP of your
+`haproxy` container.
+
+**Remember to stop the deployment with `kelda stop`!**
+
+## More Info
+For more details, check out our documentation for
+[running a replicated, load balanced application behind a single IP address](http://docs.kelda.io/#how-to-run-a-replicated-load-balanced-application-behind-a-single-ip-address).

--- a/examples/haproxyExampleMultipleApps.js
+++ b/examples/haproxyExampleMultipleApps.js
@@ -1,0 +1,38 @@
+const kelda = require('kelda');
+const haproxy = require('../haproxy');
+
+const indexPath = '/usr/share/nginx/html/index.html';
+
+/** Create a number of webservers serving the given content.
+ *
+ * @param {number} [numServers] - The desired number of web servers.
+ * @param {string} [text] - The text to put in index.html.
+ * @returns {Container[]}
+ * */
+function appWithContent(numServers, text) {
+  const appContainers = [];
+  for (let i = 0; i < numServers; i += 1) {
+    appContainers.push(new kelda.Container('web', 'nginx', {
+      filepathToContent: { [indexPath]: text },
+    }));
+  }
+  return appContainers;
+}
+
+const appleApp = appWithContent(2, 'Apples!\n');
+const orangeApp = appWithContent(2, 'Oranges!\n');
+
+// Create a load balancer to sit in front of `appContainers`.
+const loadBalancer = haproxy.withURLrouting({
+  'apples.com': appleApp,
+  'oranges.com': orangeApp,
+});
+
+// Allow requests from the public internet to the load balancer on port 80.
+loadBalancer.allowFrom(kelda.publicInternet, haproxy.exposedPort);
+
+// Deploy the application containers and load balancer.
+const inf = kelda.baseInfrastructure();
+appleApp.forEach(container => container.deploy(inf));
+orangeApp.forEach(container => container.deploy(inf));
+loadBalancer.deploy(inf);

--- a/examples/haproxyExampleSingleApp.js
+++ b/examples/haproxyExampleSingleApp.js
@@ -1,0 +1,24 @@
+const kelda = require('kelda');
+const haproxy = require('../haproxy');
+
+const indexPath = '/usr/share/nginx/html/index.html';
+
+// Replicate the application container. Here we create 3 web server (nginx)
+// containers with the text "Hello, world!" in their index file.
+const appContainers = [];
+for (let i = 0; i < 3; i += 1) {
+  appContainers.push(new kelda.Container('web', 'nginx', {
+    filepathToContent: { [indexPath]: 'Hello, world!' },
+  }));
+}
+
+// Create a load balancer to sit in front of `appContainers`.
+const loadBalancer = haproxy.simpleLoadBalancer(appContainers);
+
+// Allow requests from the public internet to the load balancer on port 80.
+loadBalancer.allowFrom(kelda.publicInternet, haproxy.exposedPort);
+
+// Deploy the application containers and load balancer.
+const inf = kelda.baseInfrastructure();
+appContainers.forEach(container => container.deploy(inf));
+loadBalancer.deploy(inf);

--- a/testInfra.js
+++ b/testInfra.js
@@ -1,0 +1,8 @@
+// This file contains the base infrastructure used for the travis build.
+function infraGetter(kelda) {
+  const vmTemplate = new kelda.Machine({ provider: 'Amazon' });
+  const infra = new kelda.Infrastructure(vmTemplate, vmTemplate.replicate(2));
+  return infra;
+}
+
+module.exports = infraGetter;


### PR DESCRIPTION
This commit adds example blueprints related to the How To guide for creating
replicated, load balanced applications.

I will submit another PR to reference these examples in our docs.